### PR TITLE
Introduce global print functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix: dropping `Print<Background<W>>` now emits a message of `(Error)` and a newline (https://github.com/heroku-buildpacks/bullet_stream/pull/20)
 - Added: `Print::global()` and `bullet_stream::global::set_writer`. Use these to preserve the newline indentation when handling dropped structs or errors ()
+- Added: `bullet_stream::global::print` functions for writing formatted output without needing to preserve state ()
+- Added: `Print::global()` and `bullet_stream::global::set_writer`. Use these to preserve the newline indentation when handling dropped structs or errors ()
 
 ## v0.3.0 - 2024/08/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased
 
-## v0.3.1 - 2024/12/21
-
 - Fix: dropping `Print<Background<W>>` now emits a message of `(Error)` and a newline (https://github.com/heroku-buildpacks/bullet_stream/pull/20)
+- Added: `Print::global()` and `bullet_stream::global::set_writer`. Use these to preserve the newline indentation when handling dropped structs or errors ()
 
 ## v0.3.0 - 2024/08/14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,8 @@
 ## Unreleased
 
 - Fix: dropping `Print<Background<W>>` now emits a message of `(Error)` and a newline (https://github.com/heroku-buildpacks/bullet_stream/pull/20)
-- Added: `Print::global()` and `bullet_stream::global::set_writer`. Use these to preserve the newline indentation when handling dropped structs or errors ()
-- Added: `bullet_stream::global::print` functions for writing formatted output without needing to preserve state ()
-- Added: `Print::global()` and `bullet_stream::global::set_writer`. Use these to preserve the newline indentation when handling dropped structs or errors ()
+- Added: `bullet_stream::global::print` functions for writing formatted output without needing to preserve state (https://github.com/heroku-buildpacks/bullet_stream/pull/21)
+- Added: `Print::global()` and `bullet_stream::global::set_writer`. Use these to preserve the newline indentation when handling dropped structs or errors (https://github.com/heroku-buildpacks/bullet_stream/pull/21)
 
 ## v0.3.0 - 2024/08/14
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,10 @@ indoc = "2.0.5"
 tempfile = "3.13.0"
 libcnb-test = "0.23.0"
 ascii_table = { version = "4.0.4", features = ["color_codes"] }
+
+[features]
+# Allow stateless printing
+global_functions = []
+
+# Enable global_functions by default
+default = ["global_functions"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This work started as a shared output format for Heroku's Cloud Native Buildpack 
 
 Add `bullet_stream` to your project:
 
-```ignore
+```term
 $ cargo add bullet_stream
 ```
 
@@ -39,7 +39,7 @@ output.done();
 
 To view the output format and read a living style guide, you can run:
 
-```ignore
+```term
 $ git clone https://github.com/schneems/bullet_stream
 $ cd bullet_stream
 $ cargo run --example style_guide

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -112,6 +112,15 @@ fn main() {
                 take to solve the issue.
             "});
     }
+    {
+        use bullet_stream::global::print;
+        print::h2("You can also print with functions");
+        print::bullet("bullet_stream::global::print");
+        print::sub_bullet("Allows you to bypass Rust's type guarantees and print directly");
+        print::sub_bullet("Call `global::set_writer` to configure the destination");
+        print::warning("WARNING:\n\nThe global functions\nProvide fewer consistency guarantees\n");
+        print::sub_bullet("See the `print` module for more info");
+    }
 
     {
         let output = Print::new(stdout()).h2("Formatting helpers");

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -1,16 +1,15 @@
 use ascii_table::AsciiTable;
-#[allow(clippy::wildcard_imports)]
+use bullet_stream::global::print;
 use bullet_stream::{style, Print};
 use fun_run::CommandWithName;
 use indoc::formatdoc;
-use std::io::stdout;
 use std::io::Write;
 use std::process::Command;
 
 #[allow(clippy::too_many_lines)]
 fn main() {
     {
-        let mut output = Print::new(stdout()).h1("Living build output style guide");
+        let mut output = Print::global().h1("Living build output style guide");
         output = output.h2("Bullet section features");
         output = output
             .bullet("Bullet example")
@@ -73,7 +72,7 @@ fn main() {
         #[allow(clippy::unwrap_used)]
         let cmd_error = Command::new("iDoNotExist").named_output().err().unwrap();
 
-        let mut output = Print::new(stdout()).h2("Error and warnings");
+        let mut output = Print::global().h2("Error and warnings");
         output = output
             .bullet("Debug information")
             .sub_bullet("Should go above errors in section/step format")
@@ -113,7 +112,6 @@ fn main() {
             "});
     }
     {
-        use bullet_stream::global::print;
         print::h2("You can also print with functions");
         print::bullet("bullet_stream::global::print");
         print::sub_bullet("Allows you to bypass Rust's type guarantees and print directly");
@@ -123,7 +121,7 @@ fn main() {
     }
 
     {
-        let output = Print::new(stdout()).h2("Formatting helpers");
+        let output = Print::global().h2("Formatting helpers");
         let mut stream = output
             .bullet(format!("The {} module", style::value("style")))
             .start_stream("Formatting helpers can be used to enhance log output:");

--- a/src/docs/global_done_one.rs
+++ b/src/docs/global_done_one.rs
@@ -1,0 +1,3 @@
+
+# let output = bullet_stream::strip_ansi(std::fs::read_to_string(&path).unwrap());
+assert_eq!(r"

--- a/src/docs/global_done_two.rs
+++ b/src/docs/global_done_two.rs
@@ -1,0 +1,1 @@
+".trim_start(), output.trim_start());

--- a/src/docs/global_setup.rs
+++ b/src/docs/global_setup.rs
@@ -1,0 +1,6 @@
+
+use bullet_stream::global::print;
+#
+# let temp = tempfile::tempdir().unwrap();
+# let path = temp.path().join("log");
+# bullet_stream::global::set_writer(std::fs::File::create(&path).unwrap());

--- a/src/global.rs
+++ b/src/global.rs
@@ -86,12 +86,18 @@ pub mod print {
     /// Output a h1 header to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
     /// print::h1("I am a top level header");
     /// let duration = std::time::Instant::now();
     /// // ...
     /// print::all_done(&Some(duration));
+    ///
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ## I am a top level header
+    ///
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn h1(s: impl AsRef<str>) {
         write::h1(&mut _GlobalWriter, s);
@@ -100,13 +106,21 @@ pub mod print {
     /// Output a h2 header to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
     /// print::h1("I am a top level header");
-    /// print::h2("I am a h2 header");
+    /// print::h2("I am an h2 header");
     /// let duration = std::time::Instant::now();
     /// // ...
     /// print::all_done(&Some(duration));
+    ///
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ## I am a top level header
+    ///
+    /// ### I am an h2 header
+    ///
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn h2(s: impl AsRef<str>) {
         write::h2(&mut _GlobalWriter, s);
@@ -115,30 +129,38 @@ pub mod print {
     /// Output a bullet point to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
     /// print::bullet("Good point!");
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// - Good point!
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn bullet(s: impl AsRef<str>) {
         write::bullet(&mut _GlobalWriter, s)
     }
 
-    /// Output a subbullet point to the global writer without state
+    /// Output a sub-bullet point to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
     /// print::bullet("Good point!");
     /// print::sub_bullet("Another good point!");
+    ///
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// - Good point!
+    ///   - Another good point!
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn sub_bullet(s: impl AsRef<str>) {
         write::sub_bullet(&mut _GlobalWriter, s);
     }
 
-    /// Stream a command to the global writer without state
+    /// Print a sub-bullet and stream a command to the global writer without state
     ///
     /// ```no_run
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     /// use fun_run::CommandWithName;
     ///
     /// let mut cmd = std::process::Command::new("bash");
@@ -156,29 +178,39 @@ pub mod print {
         write::sub_stream_with(&mut _GlobalWriter, s, f)
     }
 
-    /// Print dots to the global writer without state
+    /// Print a sub-bullet and then emmit dots to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
     /// print::bullet("Ruby");
-    /// let timer = print::start_timer("Installing");
+    /// let timer = print::sub_start_timer("Installing");
     /// // ...
     /// timer.done();
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// - Ruby
+    ///   - Installing ... (< 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn sub_start_timer(s: impl AsRef<str>) -> Print<crate::state::Background<impl Write>> {
-        write::start_timer(ParagraphInspectWrite::new(_GlobalWriter), Instant::now(), s)
+        write::sub_start_timer(ParagraphInspectWrite::new(_GlobalWriter), Instant::now(), s)
     }
 
     /// Print an all done message with timing info to the UI
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
-    /// print::h2("I am a h2 header");
+    /// print::h2("I am an h2 header");
     /// let duration = std::time::Instant::now();
     /// // ...
     /// print::all_done(&Some(duration));
+    ///
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ### I am an h2 header
+    ///
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn all_done(started: &Option<Instant>) {
         write::all_done(&mut _GlobalWriter, started);
@@ -187,9 +219,16 @@ pub mod print {
     /// Print a warning to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
     ///
-    /// print::warning("This town ain't big enough for the both of us");
+    /// print::warning("This town ain't\nbig enough\nfor the both of us");
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    ///
+    /// ! This town ain't
+    /// ! big enough
+    /// ! for the both of us
+    ///
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn warning(s: impl AsRef<str>) {
         write::warning(&mut _GlobalWriter, s);
@@ -198,9 +237,24 @@ pub mod print {
     /// Print an error to the global writer without state
     ///
     /// ```
-    /// use bullet_stream::global::print;
+    #[doc = include_str!("./docs/global_setup.rs")]
+    /// use indoc::formatdoc;
     ///
-    /// print::error("Big problemo!");
+    /// print::error(formatdoc! {"
+    ///     It's at times like this, when I'm trapped in a Vogon
+    ///     airlock with a man from Betelgeuse, and about to die of asphyxiation
+    ///     in deep space that I really wish I'd listened to what my mother told
+    ///     me when I was young
+    /// "});
+    ///
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    ///
+    /// ! It's at times like this, when I'm trapped in a Vogon
+    /// ! airlock with a man from Betelgeuse, and about to die of asphyxiation
+    /// ! in deep space that I really wish I'd listened to what my mother told
+    /// ! me when I was young
+    ///
+    #[doc = include_str!("./docs/global_done_two.rs")]
     /// ```
     pub fn error(s: impl AsRef<str>) {
         write::error(&mut _GlobalWriter, s);

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,0 +1,56 @@
+// use crate::state;
+use crate::util::ParagraphInspectWrite;
+use crate::util::TrailingParagraph;
+use crate::util::TrailingParagraphSend;
+// use crate::write;
+// use crate::Print;
+use std::io::Write;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+// use std::time::Instant;
+
+static WRITER: LazyLock<Mutex<Box<dyn TrailingParagraphSend>>> =
+    LazyLock::new(|| Mutex::new(Box::new(ParagraphInspectWrite::new(std::io::stderr()))));
+
+#[doc(hidden)]
+pub struct _GlobalWriter;
+impl Write for _GlobalWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut w = WRITER.lock().unwrap();
+        w.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut w = WRITER.lock().unwrap();
+        w.flush()
+    }
+}
+
+impl TrailingParagraph for _GlobalWriter {
+    fn trailing_paragraph(&self) -> bool {
+        let w = WRITER.lock().unwrap();
+        w.trailing_paragraph()
+    }
+
+    fn trailing_newline_count(&self) -> usize {
+        let w = WRITER.lock().unwrap();
+        w.trailing_newline_count()
+    }
+}
+
+/// Set the global writer
+///
+/// # Panics
+///
+/// If you try to pass in a `_GlobalWriter`
+pub fn set_writer<W>(new_writer: W)
+where
+    W: Write + Send + 'static,
+{
+    if std::any::Any::type_id(&new_writer) == std::any::TypeId::of::<_GlobalWriter>() {
+        panic!("Cannot set the global writer to _GlobalWriter");
+    } else {
+        let mut writer = WRITER.lock().unwrap();
+        *writer = Box::new(ParagraphInspectWrite::new(new_writer));
+    }
+}

--- a/src/global.rs
+++ b/src/global.rs
@@ -144,16 +144,16 @@ pub mod print {
     /// let mut cmd = std::process::Command::new("bash");
     /// cmd.args(["-c", "echo 'hello world'"]);
     ///
-    /// print::stream_with(format!("Running {}", cmd.name()), |stdout, stderr| {
+    /// print::sub_stream_with(format!("Running {}", cmd.name()), |stdout, stderr| {
     ///   cmd.stream_output(stdout, stderr)
     /// }).unwrap();
     /// ```
-    pub fn stream_with<F, T>(s: impl AsRef<str>, f: F) -> T
+    pub fn sub_stream_with<F, T>(s: impl AsRef<str>, f: F) -> T
     where
         F: FnMut(Box<dyn Write + Send + Sync>, Box<dyn Write + Send + Sync>) -> T,
         T: 'static,
     {
-        write::stream_with(&mut _GlobalWriter, s, f)
+        write::sub_stream_with(&mut _GlobalWriter, s, f)
     }
 
     /// Print dots to the global writer without state
@@ -166,7 +166,7 @@ pub mod print {
     /// // ...
     /// timer.done();
     /// ```
-    pub fn start_timer(s: impl AsRef<str>) -> Print<crate::state::Background<impl Write>> {
+    pub fn sub_start_timer(s: impl AsRef<str>) -> Print<crate::state::Background<impl Write>> {
         write::start_timer(ParagraphInspectWrite::new(_GlobalWriter), Instant::now(), s)
     }
 

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,13 +1,9 @@
-// use crate::state;
 use crate::util::ParagraphInspectWrite;
 use crate::util::TrailingParagraph;
 use crate::util::TrailingParagraphSend;
-// use crate::write;
-// use crate::Print;
 use std::io::Write;
 use std::sync::LazyLock;
 use std::sync::Mutex;
-// use std::time::Instant;
 
 static WRITER: LazyLock<Mutex<Box<dyn TrailingParagraphSend>>> =
     LazyLock::new(|| Mutex::new(Box::new(ParagraphInspectWrite::new(std::io::stderr()))));
@@ -40,6 +36,10 @@ impl TrailingParagraph for _GlobalWriter {
 
 /// Set the global writer
 ///
+/// ```
+/// bullet_stream::global::set_writer(std::io::stderr());
+/// ```
+///
 /// # Panics
 ///
 /// If you try to pass in a `_GlobalWriter`
@@ -52,5 +52,157 @@ where
     } else {
         let mut writer = WRITER.lock().unwrap();
         *writer = Box::new(ParagraphInspectWrite::new(new_writer));
+    }
+}
+
+#[cfg(feature = "global_functions")]
+pub mod print {
+    //! Print to a global writer without stateful protections
+    //!
+    //! The original [Print] struct provides maximum safety, which can cause max pain
+    //! if you're trying to add pretty printing to a large codebase. If that's you,
+    //! you can use these global functions to write output along with some help
+    //! from the [crate::style] module.
+    //!
+    //! The downside is that there's no compilation guarantees for example: to prevent printing
+    //! while a timer is running. Some basic consistency is still enforced such as newlines.
+    //! If using this alongside of stateful output, use [Print::global] to ensure
+    //! consistent newlines.
+    //!
+    //! Use [crate::global::set_writer] to configure the print output location.
+    //!
+    //! These functions are enabled by default. If you don't want the liability you can
+    //! disable this feature in your cargo.toml file:
+    //!
+    //! ```toml
+    //! bullet_stream = { default-features = false }
+    //! ```
+
+    use super::*;
+    use crate::write;
+    use crate::Print;
+    use std::time::Instant;
+
+    /// Output a h1 header to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::h1("I am a top level header");
+    /// let duration = std::time::Instant::now();
+    /// // ...
+    /// print::all_done(&Some(duration));
+    /// ```
+    pub fn h1(s: impl AsRef<str>) {
+        write::h1(&mut _GlobalWriter, s);
+    }
+
+    /// Output a h2 header to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::h1("I am a top level header");
+    /// print::h2("I am a h2 header");
+    /// let duration = std::time::Instant::now();
+    /// // ...
+    /// print::all_done(&Some(duration));
+    /// ```
+    pub fn h2(s: impl AsRef<str>) {
+        write::h2(&mut _GlobalWriter, s);
+    }
+
+    /// Output a bullet point to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::bullet("Good point!");
+    /// ```
+    pub fn bullet(s: impl AsRef<str>) {
+        write::bullet(&mut _GlobalWriter, s)
+    }
+
+    /// Output a subbullet point to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::bullet("Good point!");
+    /// print::sub_bullet("Another good point!");
+    /// ```
+    pub fn sub_bullet(s: impl AsRef<str>) {
+        write::sub_bullet(&mut _GlobalWriter, s);
+    }
+
+    /// Stream a command to the global writer without state
+    ///
+    /// ```no_run
+    /// use bullet_stream::global::print;
+    /// use fun_run::CommandWithName;
+    ///
+    /// let mut cmd = std::process::Command::new("bash");
+    /// cmd.args(["-c", "echo 'hello world'"]);
+    ///
+    /// print::stream_with(format!("Running {}", cmd.name()), |stdout, stderr| {
+    ///   cmd.stream_output(stdout, stderr)
+    /// }).unwrap();
+    /// ```
+    pub fn stream_with<F, T>(s: impl AsRef<str>, f: F) -> T
+    where
+        F: FnMut(Box<dyn Write + Send + Sync>, Box<dyn Write + Send + Sync>) -> T,
+        T: 'static,
+    {
+        write::stream_with(&mut _GlobalWriter, s, f)
+    }
+
+    /// Print dots to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::bullet("Ruby");
+    /// let timer = print::start_timer("Installing");
+    /// // ...
+    /// timer.done();
+    /// ```
+    pub fn start_timer(s: impl AsRef<str>) -> Print<crate::state::Background<impl Write>> {
+        write::start_timer(ParagraphInspectWrite::new(_GlobalWriter), Instant::now(), s)
+    }
+
+    /// Print an all done message with timing info to the UI
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::h2("I am a h2 header");
+    /// let duration = std::time::Instant::now();
+    /// // ...
+    /// print::all_done(&Some(duration));
+    /// ```
+    pub fn all_done(started: &Option<Instant>) {
+        write::all_done(&mut _GlobalWriter, started);
+    }
+
+    /// Print a warning to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::warning("This town ain't big enough for the both of us");
+    /// ```
+    pub fn warning(s: impl AsRef<str>) {
+        write::warning(&mut _GlobalWriter, s);
+    }
+
+    /// Print an error to the global writer without state
+    ///
+    /// ```
+    /// use bullet_stream::global::print;
+    ///
+    /// print::error("Big problemo!");
+    /// ```
+    pub fn error(s: impl AsRef<str>) {
+        write::error(&mut _GlobalWriter, s);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-use crate::ansi_escape::ANSI;
-use crate::util::{
-    mpsc_stream_to_output, prefix_first_rest_lines, prefix_lines, ParagraphInspectWrite,
-};
+use crate::util::ParagraphInspectWrite;
 use crate::write::line_mapped;
 use std::fmt::Debug;
 use std::io::Write;
@@ -15,8 +12,8 @@ mod duration_format;
 pub mod style;
 mod util;
 mod write;
-
 pub use ansi_escape::strip_ansi;
+use style::CMD_INDENT;
 
 /// Use [`Print`] to output structured text as a buildpack/script executes. The output
 /// is intended to be read by the application user.
@@ -276,7 +273,7 @@ where
     /// using a [`Print::warning`] instead.
     ///
     pub fn error(mut self, s: impl AsRef<str>) {
-        self.write_paragraph(&ANSI::Red, s);
+        write::error(self.state.write_mut(), s);
     }
 
     /// Emit a warning message to the end user.
@@ -298,7 +295,7 @@ where
     /// state except for [`state::Header`].
     #[must_use]
     pub fn warning(mut self, s: impl AsRef<str>) -> Print<S> {
-        self.write_paragraph(&ANSI::Yellow, s);
+        write::warning(self.state.write_mut(), s);
         self
     }
 
@@ -314,41 +311,14 @@ where
     /// [`Print::warning`] instead.
     #[must_use]
     pub fn important(mut self, s: impl AsRef<str>) -> Print<S> {
-        self.write_paragraph(&ANSI::BoldCyan, s);
+        write::important(self.state.write_mut(), s);
         self
-    }
-
-    fn write_paragraph(&mut self, color: &ANSI, s: impl AsRef<str>) {
-        let io = self.state.write_mut();
-        let contents = s.as_ref().trim();
-
-        if !io.was_paragraph {
-            writeln_now(io, "");
-        }
-
-        writeln_now(
-            io,
-            ansi_escape::wrap_ansi_escape_each_line(
-                color,
-                prefix_lines(contents, |_, line| {
-                    // Avoid adding trailing whitespace to the line, if there was none already.
-                    // The `\n` case is required since `prefix_lines` uses `str::split_inclusive`,
-                    // which preserves any trailing newline characters if present.
-                    if line.is_empty() || line == "\n" {
-                        String::from("!")
-                    } else {
-                        String::from("! ")
-                    }
-                }),
-            ),
-        );
-        writeln_now(io, "");
     }
 }
 
 impl<W> Print<state::Header<W>>
 where
-    W: Write,
+    W: Write + Send + Sync + 'static,
 {
     /// Create a buildpack output struct, but do not announce the buildpack's start.
     ///
@@ -376,14 +346,8 @@ where
     ///
     /// This function will transition your buildpack output to [`state::Bullet`].
     #[must_use]
-    pub fn h1(mut self, buildpack_name: impl AsRef<str>) -> Print<state::Bullet<W>> {
-        writeln_now(
-            &mut self.state.write,
-            ansi_escape::wrap_ansi_escape_each_line(
-                &ANSI::BoldPurple,
-                format!("\n# {}\n", buildpack_name.as_ref().trim()),
-            ),
-        );
+    pub fn h1(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
+        write::h1(&mut self.state.write, s);
 
         self.without_header()
     }
@@ -401,18 +365,8 @@ where
     ///
     /// This function will transition your buildpack output to [`state::Bullet`].
     #[must_use]
-    pub fn h2(mut self, buildpack_name: impl AsRef<str>) -> Print<state::Bullet<W>> {
-        if !self.state.write.was_paragraph {
-            writeln_now(&mut self.state.write, "");
-        }
-
-        writeln_now(
-            &mut self.state.write,
-            ansi_escape::wrap_ansi_escape_each_line(
-                &ANSI::BoldPurple,
-                format!("## {}\n", buildpack_name.as_ref().trim()),
-            ),
-        );
+    pub fn h2(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
+        write::h2(&mut self.state.write, s);
 
         self.without_header()
     }
@@ -433,13 +387,6 @@ impl<W> Print<state::Bullet<W>>
 where
     W: Write + Send + Sync + 'static,
 {
-    const PREFIX_FIRST: &'static str = "- ";
-    const PREFIX_REST: &'static str = "  ";
-
-    fn style(s: impl AsRef<str>) -> String {
-        prefix_first_rest_lines(Self::PREFIX_FIRST, Self::PREFIX_REST, s.as_ref().trim())
-    }
-
     /// A top-level bullet point section
     ///
     /// A section should be a noun, e.g., 'Ruby version'. Anything emitted within the section
@@ -452,7 +399,7 @@ where
     /// This function will transition your buildpack output to [`state::SubBullet`].
     #[must_use]
     pub fn bullet(mut self, s: impl AsRef<str>) -> Print<state::SubBullet<W>> {
-        writeln_now(&mut self.state.write, Self::style(s));
+        write::bullet(&mut self.state.write, s);
 
         Print {
             started: self.started,
@@ -464,34 +411,14 @@ where
 
     /// Outputs an H2 header
     #[must_use]
-    pub fn h2(mut self, buildpack_name: impl AsRef<str>) -> Print<state::Bullet<W>> {
-        if !self.state.write.was_paragraph {
-            writeln_now(&mut self.state.write, "");
-        }
-
-        writeln_now(
-            &mut self.state.write,
-            ansi_escape::wrap_ansi_escape_each_line(
-                &ANSI::BoldPurple,
-                format!("## {}\n", buildpack_name.as_ref().trim()),
-            ),
-        );
-
+    pub fn h2(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
+        write::h2(&mut self.state.write, s);
         self
     }
 
     /// Announce that your buildpack has finished execution successfully.
     pub fn done(mut self) -> W {
-        if let Some(started) = &self.started {
-            let elapsed = duration_format::human(&started.elapsed());
-            let details = style::details(format!("finished in {elapsed}"));
-            writeln_now(
-                &mut self.state.write,
-                Self::style(format!("Done {details}")),
-            );
-        } else {
-            writeln_now(&mut self.state.write, Self::style("Done"));
-        }
+        write::all_done(&mut self.state.write, &self.started);
 
         self.state.write.inner
     }
@@ -574,14 +501,6 @@ impl<W> Print<state::SubBullet<W>>
 where
     W: Write + Send + Sync + 'static,
 {
-    const PREFIX_FIRST: &'static str = "  - ";
-    const PREFIX_REST: &'static str = "    ";
-    const CMD_INDENT: &'static str = "      ";
-
-    fn style(s: impl AsRef<str>) -> String {
-        prefix_first_rest_lines(Self::PREFIX_FIRST, Self::PREFIX_REST, s.as_ref().trim())
-    }
-
     /// Emit a sub bullet point step in the output under a bullet point.
     ///
     /// A step should be a verb, i.e., 'Downloading'. Related verbs should be nested under a single section.
@@ -607,7 +526,7 @@ where
     /// Multiple steps are allowed within a section. This function returns to the same [`state::SubBullet`].
     #[must_use]
     pub fn sub_bullet(mut self, s: impl AsRef<str>) -> Print<state::SubBullet<W>> {
-        writeln_now(&mut self.state.write, Self::style(s));
+        write::sub_bullet(&mut self.state.write, s);
         self
     }
 
@@ -624,7 +543,7 @@ where
     /// This function will transition your buildpack output to [`state::Stream`].
     #[must_use]
     pub fn start_stream(mut self, s: impl AsRef<str>) -> Print<state::Stream<W>> {
-        writeln_now(&mut self.state.write, Self::style(s));
+        write::sub_bullet(&mut self.state.write, s);
         writeln_now(&mut self.state.write, "");
 
         Print {
@@ -637,7 +556,7 @@ where
                     if line.is_empty() || line == [b'\n'] {
                         line
                     } else {
-                        let mut result: Vec<u8> = Self::CMD_INDENT.into();
+                        let mut result: Vec<u8> = CMD_INDENT.into();
                         result.append(&mut line);
                         result
                     }
@@ -658,45 +577,9 @@ where
     /// This function will transition your buildpack output to [`state::Background`].
     #[allow(clippy::missing_panics_doc)]
     #[must_use]
+    #[allow(unused_mut)]
     pub fn start_timer(mut self, s: impl AsRef<str>) -> Print<state::Background<W>> {
-        // Do not emit a newline after the message
-        write!(self.state.write, "{}", Self::style(s)).expect("Output error: UI writer closed");
-        self.state
-            .write
-            .flush()
-            .expect("Output error: UI writer closed");
-
-        Print {
-            started: self.started,
-            state: state::Background {
-                started: Instant::now(),
-                write: background_printer::print_interval(
-                    self.state.write,
-                    std::time::Duration::from_secs(1),
-                    ansi_escape::wrap_ansi_escape_each_line(&ANSI::Dim, " ."),
-                    ansi_escape::wrap_ansi_escape_each_line(&ANSI::Dim, "."),
-                    ansi_escape::wrap_ansi_escape_each_line(&ANSI::Dim, ". "),
-                    "(Error)".to_string(),
-                ),
-            },
-        }
-    }
-
-    fn format_stream_writer<S>(stream_to: S) -> crate::write::MappedWrite<S>
-    where
-        S: Write + Send + Sync,
-    {
-        line_mapped(stream_to, |mut line| {
-            // Avoid adding trailing whitespace to the line, if there was none already.
-            // The `[b'\n']` case is required since `line` includes the trailing newline byte.
-            if line.is_empty() || line == [b'\n'] {
-                line
-            } else {
-                let mut result: Vec<u8> = Self::CMD_INDENT.into();
-                result.append(&mut line);
-                result
-            }
-        })
+        write::start_timer(self.state.write, Instant::now(), s)
     }
 
     /// Stream two inputs without consuming
@@ -731,48 +614,12 @@ where
     /// output.done().done();
     /// ```
     #[allow(clippy::missing_panics_doc)]
-    pub fn stream_with<F, T>(&mut self, s: impl AsRef<str>, mut f: F) -> T
+    pub fn stream_with<F, T>(&mut self, s: impl AsRef<str>, f: F) -> T
     where
         F: FnMut(Box<dyn Write + Send + Sync>, Box<dyn Write + Send + Sync>) -> T,
         T: 'static,
     {
-        writeln_now(&mut self.state.write, Self::style(s));
-        writeln_now(&mut self.state.write, "");
-
-        let duration = Instant::now();
-        mpsc_stream_to_output(
-            |sender| {
-                f(
-                    // The Senders are boxed to hide the types from the caller so it can be changed
-                    // in the future. They only need to know they have a `Write + Send + Sync` type.
-                    Box::new(Self::format_stream_writer(sender.clone())),
-                    Box::new(Self::format_stream_writer(sender.clone())),
-                )
-            },
-            move |recv| {
-                // When it receives input, it writes it to the current `Write` value.
-                //
-                // When the senders close their channel this loop will exit
-                for message in recv {
-                    self.state
-                        .write
-                        .write_all(&message)
-                        .expect("Writer to not be closed");
-                }
-
-                if !self.state.write_mut().was_paragraph {
-                    writeln_now(&mut self.state.write, "");
-                }
-
-                writeln_now(
-                    &mut self.state.write,
-                    Self::style(format!(
-                        "Done {}",
-                        style::details(duration_format::human(&duration.elapsed()))
-                    )),
-                );
-            },
-        )
+        write::stream_with(&mut self.state.write, s, f)
     }
 
     /// Finish a section and transition back to [`state::Bullet`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1055,7 +1055,7 @@ mod test {
     }
 
     thread_local! {
-        static THREAD_LOCAL_WRITER: RefCell<Vec<u8>> = RefCell::new(Vec::new());
+        static THREAD_LOCAL_WRITER: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     }
 
     struct V8ThreadedWriter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -600,7 +600,7 @@ where
     #[must_use]
     #[allow(unused_mut)]
     pub fn start_timer(mut self, s: impl AsRef<str>) -> Print<state::Background<W>> {
-        write::start_timer(self.state.write, Instant::now(), s)
+        write::sub_start_timer(self.state.write, Instant::now(), s)
     }
 
     /// Stream two inputs without consuming
@@ -640,7 +640,7 @@ where
         F: FnMut(Box<dyn Write + Send + Sync>, Box<dyn Write + Send + Sync>) -> T,
         T: 'static,
     {
-        write::stream_with(&mut self.state.write, s, f)
+        write::sub_stream_with(&mut self.state.write, s, f)
     }
 
     /// Finish a section and transition back to [`state::Bullet`].

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,6 +1,7 @@
 //! Helpers for formatting and colorizing your output.
 
 use crate::ansi_escape::{self, ANSI};
+pub(crate) const CMD_INDENT: &str = "      ";
 
 /// Decorate a URL for the build output.
 pub fn url(contents: impl AsRef<str>) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -72,6 +72,8 @@ pub(crate) struct ParagraphInspectWrite<W> {
 pub(crate) trait TrailingParagraph: Write {
     /// True if the last thing written was two newlines
     fn trailing_paragraph(&self) -> bool;
+
+    fn trailing_newline_count(&self) -> usize;
 }
 
 pub(crate) trait TrailingParagraphSend: TrailingParagraph + Send {}
@@ -83,6 +85,10 @@ where
 {
     fn trailing_paragraph(&self) -> bool {
         self.was_paragraph
+    }
+
+    fn trailing_newline_count(&self) -> usize {
+        self.newlines_since_last_char
     }
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -59,10 +59,12 @@ pub(crate) fn bullet<W: Write>(writer: &mut W, s: impl AsRef<str>) {
         prefix_first_rest_lines("- ", "  ", s.as_ref().trim())
     )
     .expect("writer open");
+    writer.flush().expect("writer open");
 }
 
 pub(crate) fn sub_bullet<W: Write>(writer: &mut W, s: impl AsRef<str>) {
     writeln!(writer, "{}", sub_bullet_prefix(s)).expect("writer open");
+    writer.flush().expect("writer open");
 }
 
 pub(crate) fn sub_bullet_prefix(s: impl AsRef<str>) -> String {

--- a/src/write.rs
+++ b/src/write.rs
@@ -71,7 +71,7 @@ pub(crate) fn sub_bullet_prefix(s: impl AsRef<str>) -> String {
     prefix_first_rest_lines("  - ", "    ", s.as_ref().trim())
 }
 
-pub(crate) fn stream_with<W, T, F>(writer: &mut W, s: impl AsRef<str>, mut f: F) -> T
+pub(crate) fn sub_stream_with<W, T, F>(writer: &mut W, s: impl AsRef<str>, mut f: F) -> T
 where
     W: TrailingParagraphSend,
     F: FnMut(Box<dyn Write + Send + Sync>, Box<dyn Write + Send + Sync>) -> T,
@@ -113,7 +113,7 @@ where
     )
 }
 
-pub(crate) fn start_timer<W>(
+pub(crate) fn sub_start_timer<W>(
     mut writer: ParagraphInspectWrite<W>,
     started: Instant,
     s: impl AsRef<str>,


### PR DESCRIPTION
- Introduces `bullet_stream::global::print` functions for printing without needing to jump through strict type checked stateful hoops. It's less safe, but faster to get up and running.
- Introduces `Print::global()` which supports resuming printing after an error.