### PR TITLE
Refactor shared "announce" code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/src/docs/stateful_error.md
+++ b/src/docs/stateful_error.md
@@ -1,0 +1,17 @@
+Emit an error and end the build output.
+
+When an unrecoverable situation is encountered, you can emit an error message to the user.
+This associated function will consume the build output, so you may only emit one error per
+build output.
+
+An error message should describe what went wrong and why the buildpack cannot continue.
+It is best practice to include debugging information in the error message. For example,
+if a file is missing, consider showing the user the contents of the directory where the
+file was expected to be and the full path of the file.
+
+If you are confident about what action needs to be taken to fix the error, you should include
+that in the error message. Do not write a generic suggestion like "try again later" unless
+you are certain that the error is transient.
+
+If you detect something problematic but not bad enough to halt buildpack execution, consider
+using a [`Print::warning`] instead.

--- a/src/docs/stateful_important.md
+++ b/src/docs/stateful_important.md
@@ -1,0 +1,10 @@
+Emit an important message to the end user.
+
+When something significant happens but is not inherently negative, you can use an important
+message. For example, if a buildpack detects that the operating system or architecture has
+changed since the last build, it might not be a problem, but if something goes wrong, the
+user should know about it.
+
+Important messages should be used sparingly and only for things the user should be aware of
+but not necessarily act on. If the message is actionable, consider using a
+[`Print::warning`] instead.

--- a/src/docs/stateful_warning.md
+++ b/src/docs/stateful_warning.md
@@ -1,0 +1,17 @@
+Emit a warning message to the end user.
+
+A warning should be used to emit a message to the end user about a potential problem.
+
+Multiple warnings can be emitted in sequence. The buildpack author should take care not to
+overwhelm the end user with unnecessary warnings.
+
+When emitting a warning, describe the problem to the user, if possible, and tell them how
+to fix it or where to look next.
+
+Warnings should often come with some disabling mechanism, if possible. If the user can turn
+off the warning, that information should be included in the warning message. If you're
+confident that the user should not be able to turn off a warning, consider using a
+[`Print::error`] instead.
+
+Warnings will be output in a multi-line paragraph style. A warning can be emitted from any
+state except for [`state::Header`].


### PR DESCRIPTION
The prior implementation relied on an internal trait to give identical implementations of the "announcement" states i.e. error/warning/important to Bullet and SubBullet. This was always a little difficult to work with. Since the refactor of this logic into the shared `write.rs` module, we can instead duplicate the code and rely on the internal interface to share instead. This is more ergonomic.

This commit is a pure refactor, the end user should see no change.