### PR TITLE
Add ability to return the original writer W after an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added: `Print<T>::error()` now returns the original writer `W`, this allows for building error messages (`Vec<u8>`) with debug output above it using the stateful API. See the tests for an example (https://github.com/heroku-buildpacks/bullet_stream/pull/28)
+
 ## v0.5.0 - 2025/01/31
 
 - A `fun_run` feature to provide optional interfaces when the `fun_run` crate is being used. PR: (https://github.com/heroku-buildpacks/bullet_stream/pull/25)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,8 +339,9 @@ where
     }
 
     #[doc = include_str!("docs/stateful_error.md")]
-    pub fn error(mut self, s: impl AsRef<str>) {
+    pub fn error(mut self, s: impl AsRef<str>) -> W {
         write::error(&mut self.state.write, s);
+        self.state.write.inner
     }
 
     #[must_use]
@@ -642,8 +643,9 @@ where
     }
 
     #[doc = include_str!("docs/stateful_error.md")]
-    pub fn error(mut self, s: impl AsRef<str>) {
+    pub fn error(mut self, s: impl AsRef<str>) -> W {
         write::error(&mut self.state.write, s);
+        self.state.write.inner
     }
 
     #[must_use]
@@ -878,10 +880,7 @@ mod test {
 
     #[test]
     fn paragraph_color_codes() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let path = tmpdir.path().join("output.txt");
-
-        Print::new(File::create(&path).unwrap())
+        let io = Print::new(Vec::new())
             .h1("Buildpack Header is Bold Purple")
             .important("Important is bold cyan")
             .warning("Warnings are yellow")
@@ -899,7 +898,7 @@ mod test {
 
         "};
 
-        assert_eq!(expected, std::fs::read_to_string(path).unwrap());
+        assert_eq!(expected, String::from_utf8_lossy(&io));
     }
 
     #[test]
@@ -924,10 +923,7 @@ mod test {
 
     #[test]
     fn test_error() {
-        let tmpdir = tempfile::tempdir().unwrap();
-        let path = tmpdir.path().join("output.txt");
-
-        Print::new(File::create(&path).unwrap())
+        let io = Print::new(Vec::new())
             .h1("Heroku Ruby Buildpack")
             .error("This is an error");
 
@@ -939,7 +935,7 @@ mod test {
 
         "};
 
-        assert_eq!(expected, strip_ansi(std::fs::read_to_string(path).unwrap()));
+        assert_eq!(expected, strip_ansi(String::from_utf8_lossy(&io)));
     }
 
     #[test]


### PR DESCRIPTION
Allows encapsulation of error messages like this (pseudo code):

```rust
impl Display for ErrorMessage {
    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
        let mut log = Print::new(Vec::new()).without_header();
        if let Some(debug_info) = &self.debug_info {
            log = log
                .bullet(style::important("Debug Info:"))
                .sub_bullet(debug_info)
                .done();
        }
        let io = log.error(&self.message);
        write!(f, "{}", String::from_utf8_lossy(&io))
    }
} 
```