### PR TITLE
Add H3 header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add: explicit `print::buildpack` and `print::header` functions that are focused on intent rather than implementation detail (https://github.com/heroku-buildpacks/bullet_stream/pull/34)
 - Add: `h3` header support (https://github.com/heroku-buildpacks/bullet_stream/pull/32)
 - Add: `global::print::plain` to print out plain text like `println!`. It auto-flushes IO, redirects to the global writer (if you wanted to capture everything), and enables "paragraph detection" if it's followed by something like a warning or error ()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add: `h3` header support (https://github.com/heroku-buildpacks/bullet_stream/pull/32)
 - Add: `global::print::plain` to print out plain text like `println!`. It auto-flushes IO, redirects to the global writer (if you wanted to capture everything), and enables "paragraph detection" if it's followed by something like a warning or error ()
 
 ## v0.6.1 - 2024/02/11

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -10,7 +10,6 @@ use std::process::Command;
 fn main() {
     {
         let mut output = Print::global().h1("Living build output style guide");
-
         print::h2("Buildpack Detect output");
         print::bullet(
             "
@@ -35,6 +34,26 @@ fn main() {
             The name like `heroku/dotnet` is already included in the output.
         "});
         print::plain("");
+
+        output = output.h2("Header usage");
+        let mut bullet = output.bullet(formatdoc! {"
+            Header levels
+        "});
+        bullet = bullet.sub_bullet(formatdoc! {"
+            H1: The H1 header appears at most once in a given output.
+        "});
+        bullet = bullet.sub_bullet(formatdoc! {"
+            H2: Buildpacks use H2 for announcing the name of the buildpack.
+
+            Use the full name in title case such as 'Heroku Ruby Buildpack'
+        "});
+        bullet = bullet.sub_bullet(formatdoc! {"
+            H3: The H3 header can be used to add an extra nesting level by breaking
+            up bullet sections.
+
+            Prefer using h2, bullet, and sub-bullet indentation levels when possible.
+        "});
+        output = bullet.done();
 
         output = output.h2("Bullet section features");
         output = output
@@ -139,8 +158,8 @@ fn main() {
     }
     {
         print::h2("You can also print with functions");
-        print::bullet("bullet_stream::global::print");
-        print::sub_bullet("Allows you to bypass Rust's type guarantees and print directly");
+        print::h3("bullet_stream::global::print");
+        print::bullet("Allows you to bypass Rust's type guarantees and print directly");
         print::sub_bullet("Call `global::set_writer` to configure the destination");
         print::warning("WARNING:\n\nThe global functions\nProvide fewer consistency guarantees\n");
         print::sub_bullet("See the `print` module for more info");

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -35,25 +35,19 @@ fn main() {
         "});
         print::plain("");
 
-        output = output.h2("Header usage");
-        let mut bullet = output.bullet(formatdoc! {"
-            Header levels
+        print::buildpack("Buildpack Name");
+        print::bullet("Use `print::buildpack()` to announce the name of your buildpack");
+        print::bullet(formatdoc! {"
+            Use the full name in a title case. For example: `heroku/ruby`
+            would become print::buildpack(\"Heroku Ruby Buildpack\");
         "});
-        bullet = bullet.sub_bullet(formatdoc! {"
-            H1: The H1 header appears at most once in a given output.
-        "});
-        bullet = bullet.sub_bullet(formatdoc! {"
-            H2: Buildpacks use H2 for announcing the name of the buildpack.
-
-            Use the full name in title case such as 'Heroku Ruby Buildpack'
-        "});
-        bullet = bullet.sub_bullet(formatdoc! {"
-            H3: The H3 header can be used to add an extra nesting level by breaking
+        print::header("Header");
+        print::bullet(formatdoc! {"
+            You can use `print::header()` to add an extra nesting level by breaking
             up bullet sections.
 
             Prefer using h2, bullet, and sub-bullet indentation levels when possible.
         "});
-        output = bullet.done();
 
         output = output.h2("Bullet section features");
         output = output

--- a/src/docs/global_setup.rs
+++ b/src/docs/global_setup.rs
@@ -1,5 +1,6 @@
 
 use bullet_stream::global::print;
+# use pretty_assertions::{assert_eq, assert_ne};
 #
 # let temp = tempfile::tempdir().unwrap();
 # let path = temp.path().join("log");

--- a/src/global.rs
+++ b/src/global.rs
@@ -171,7 +171,6 @@ pub mod print {
     ///
     /// ```
     #[doc = include_str!("./docs/global_setup.rs")]
-    ///
     /// print::plain("This almost seems silly.");
     /// print::plain("But it auto-flushes IO.");
     /// print::plain("Which is nice.");
@@ -183,6 +182,73 @@ pub mod print {
     /// ```
     pub fn plain(s: impl AsRef<str>) {
         write::plain(&mut GlobalWriter, s)
+    }
+
+    /// Announce the name of a buildpack
+    ///
+    /// Use together with [all_done]
+    /// ```
+    #[doc = include_str!("./docs/global_setup.rs")]
+    /// let started = print::buildpack("Heroku Awesome Buildpack");
+    /// print::bullet("Just add awesome.");
+    /// print::all_done(&Some(started));
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ### Heroku Awesome Buildpack
+    ///
+    /// - Just add awesome.
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
+    /// ```
+    pub fn buildpack(s: impl AsRef<str>) -> Instant {
+        write::h2(&mut GlobalWriter, s);
+        Instant::now()
+    }
+
+    /// Header to break up subsections in a buildpack's output
+    ///
+    /// ```
+    #[doc = include_str!("./docs/global_setup.rs")]
+    ///
+    /// let started = print::buildpack("FYEO Buildpack");
+    ///
+    /// print::header("the branches bending low");
+    /// print::bullet("Tracks");
+    /// print::sub_bullet("all the windows are glowing");
+    /// print::sub_bullet("looking in between those long reeds");
+    /// print::bullet("Released");
+    /// print::sub_bullet("2024");
+    ///
+    /// print::header("failed book plots");
+    /// print::bullet("Tracks");
+    /// print::sub_bullet("the stream at new river beach ");
+    /// print::sub_bullet("a line that is broad");
+    /// print::bullet("Released");
+    /// print::sub_bullet("2023");
+    ///
+    /// print::all_done(&Some(started));
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ### FYEO Buildpack
+    ///
+    /// #### the branches bending low
+    ///
+    /// - Tracks
+    ///   - all the windows are glowing
+    ///   - looking in between those long reeds
+    /// - Released
+    ///   - 2024
+    ///
+    /// #### failed book plots
+    ///
+    /// - Tracks
+    ///   - the stream at new river beach
+    ///   - a line that is broad
+    /// - Released
+    ///   - 2023
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
+    /// ```
+    pub fn header(s: impl AsRef<str>) {
+        write::h3(&mut GlobalWriter, s);
     }
 
     /// Output a bullet point to the global writer without state

--- a/src/global.rs
+++ b/src/global.rs
@@ -139,6 +139,31 @@ pub mod print {
         write::h2(&mut GlobalWriter, s);
     }
 
+    /// Output a h3 header to the global writer without state
+    ///
+    /// ```
+    #[doc = include_str!("./docs/global_setup.rs")]
+    /// print::h1("I am a top level header");
+    /// print::h2("I am an h2 header");
+    /// print::h3("I am an h3 header");
+    /// let duration = std::time::Instant::now();
+    /// // ...
+    /// print::all_done(&Some(duration));
+    ///
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ## I am a top level header
+    ///
+    /// ### I am an h2 header
+    ///
+    /// #### I am an h3 header
+    ///
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
+    /// ```
+    pub fn h3(s: impl AsRef<str>) {
+        write::h3(&mut GlobalWriter, s);
+    }
+
     /// Output plain text
     ///
     /// Like `println!` but it writes to the shared global

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,7 +289,12 @@ where
     #[must_use]
     pub fn h2(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
         write::h2(&mut self.state.write, s);
+        self.without_header()
+    }
 
+    #[must_use]
+    pub fn h3(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
+        write::h3(&mut self.state.write, s);
         self.without_header()
     }
 
@@ -335,6 +340,12 @@ where
     #[must_use]
     pub fn h2(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
         write::h2(&mut self.state.write, s);
+        self
+    }
+
+    #[must_use]
+    pub fn h3(mut self, s: impl AsRef<str>) -> Print<state::Bullet<W>> {
+        write::h3(&mut self.state.write, s);
         self
     }
 
@@ -738,7 +749,10 @@ mod test {
     #[test]
     fn double_h2_h2_newlines() {
         let writer = Vec::new();
-        let output = Print::new(writer).h2("Header 2").h2("Header 2");
+        let output = Print::new(writer)
+            .h2("Header 2")
+            .h2("Header 2")
+            .h3("Header 3");
 
         let io = output.done();
         let expected = formatdoc! {"
@@ -746,6 +760,8 @@ mod test {
             ## Header 2
 
             ## Header 2
+
+            ### Header 3
 
             - Done (finished in < 0.1s)
         "};
@@ -764,6 +780,22 @@ mod test {
             # Header 1
 
             ## Header 2
+
+            - Done (finished in < 0.1s)
+        "};
+
+        assert_eq!(expected, strip_ansi(String::from_utf8_lossy(&io)))
+    }
+
+    #[test]
+    fn h3_first() {
+        let writer = Vec::new();
+        let output = Print::new(writer).h3("Header 3");
+
+        let io = output.done();
+        let expected = formatdoc! {"
+
+            ### Header 3
 
             - Done (finished in < 0.1s)
         "};

--- a/src/write.rs
+++ b/src/write.rs
@@ -58,15 +58,7 @@ pub(crate) fn h3<W: TrailingParagraph>(writer: &mut W, s: impl AsRef<str>) {
         writeln!(writer).expect("writer open");
     }
 
-    writeln!(
-        writer,
-        "{}",
-        ansi_escape::wrap_ansi_escape_each_line(
-            &ANSI::BoldPurple,
-            format!("### {}", s.as_ref().trim()),
-        ),
-    )
-    .expect("writer open");
+    writeln!(writer, "### {}", s.as_ref().trim()).expect("writer open");
 
     if !writer.trailing_paragraph() {
         writeln!(writer).expect("writer open");

--- a/src/write.rs
+++ b/src/write.rs
@@ -53,6 +53,27 @@ pub(crate) fn h2<W: TrailingParagraph>(writer: &mut W, s: impl AsRef<str>) {
     writer.flush().expect("writer open");
 }
 
+pub(crate) fn h3<W: TrailingParagraph>(writer: &mut W, s: impl AsRef<str>) {
+    if !writer.trailing_paragraph() {
+        writeln!(writer).expect("writer open");
+    }
+
+    writeln!(
+        writer,
+        "{}",
+        ansi_escape::wrap_ansi_escape_each_line(
+            &ANSI::BoldPurple,
+            format!("### {}", s.as_ref().trim()),
+        ),
+    )
+    .expect("writer open");
+
+    if !writer.trailing_paragraph() {
+        writeln!(writer).expect("writer open");
+    }
+    writer.flush().expect("writer open");
+}
+
 pub(crate) fn bullet<W: Write>(writer: &mut W, s: impl AsRef<str>) {
     writeln!(
         writer,


### PR DESCRIPTION
Adds the H3 header level with suggestions on how to use it.

Since we are limited to two nesting levels:

```
- one
  - two
```

Buildpack authors can use h3 to break up sections:

```
### Key context

- one
  - two

### Different context

- one
  - two
```

Close #23