### PR TITLE
Add: `global::print::plain` for plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add: `global::print::plain` to print out plain text like `println!`. It auto-flushes IO, redirects to the global writer (if you wanted to capture everything), and enables "paragraph detection" if it's followed by something like a warning or error ()
+
 ## v0.6.1 - 2024/02/11
 
 - Fix: Relax the constraint of `fun_run` optional dependency. Now any version higher than `0.5` and less than `1.0` is will work. (https://github.com/heroku-buildpacks/bullet_stream/pull/30)

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -10,6 +10,32 @@ use std::process::Command;
 fn main() {
     {
         let mut output = Print::global().h1("Living build output style guide");
+
+        print::h2("Buildpack Detect output");
+        print::bullet(
+            "
+            Detect phase is when a buildpack declares if it can run or not.
+        ",
+        );
+        print::sub_bullet("Use `print::plain()` style.");
+        print::sub_bullet(formatdoc! {"
+            When the buildpack can run, nothing should be printed.
+            If the buildpack cannot be run, print the reason why.
+
+            Output should be a sentence with capitalized first letter, ending in a period.
+            Include specific contents required to hint how to fix detection.
+        "});
+        print::bullet("Good detect message:");
+        print::sub_bullet("No solution or project files found (`.sln` or `.csproj`).");
+        print::bullet("Poor detect message:");
+        print::sub_bullet("No project files found.");
+        print::plain("");
+        print::plain(formatdoc! {"
+            FYI: You do not need to repeat the name of your buildpack or language.
+            The name like `heroku/dotnet` is already included in the output.
+        "});
+        print::plain("");
+
         output = output.h2("Bullet section features");
         output = output
             .bullet("Bullet example")

--- a/src/global.rs
+++ b/src/global.rs
@@ -139,6 +139,27 @@ pub mod print {
         write::h2(&mut GlobalWriter, s);
     }
 
+    /// Output plain text
+    ///
+    /// Like `println!` but it writes to the shared global
+    /// writer.
+    ///
+    /// ```
+    #[doc = include_str!("./docs/global_setup.rs")]
+    ///
+    /// print::plain("This almost seems silly.");
+    /// print::plain("But it auto-flushes IO.");
+    /// print::plain("Which is nice.");
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// This almost seems silly.
+    /// But it auto-flushes IO.
+    /// Which is nice.
+    #[doc = include_str!("./docs/global_done_two.rs")]
+    /// ```
+    pub fn plain(s: impl AsRef<str>) {
+        write::plain(&mut GlobalWriter, s)
+    }
+
     /// Output a bullet point to the global writer without state
     ///
     /// ```

--- a/src/write.rs
+++ b/src/write.rs
@@ -63,6 +63,11 @@ pub(crate) fn bullet<W: Write>(writer: &mut W, s: impl AsRef<str>) {
     writer.flush().expect("writer open");
 }
 
+pub(crate) fn plain<W: Write>(writer: &mut W, s: impl AsRef<str>) {
+    writeln!(writer, "{}", s.as_ref()).expect("writer open");
+    writer.flush().expect("writer open");
+}
+
 pub(crate) fn sub_bullet<W: Write>(writer: &mut W, s: impl AsRef<str>) {
     writeln!(writer, "{}", sub_bullet_prefix(s)).expect("writer open");
     writer.flush().expect("writer open");


### PR DESCRIPTION
It's like `println!`. However, It auto-flushes IO, redirects to the global writer (if you wanted to capture everything), and enables "paragraph detection" if it's followed by something like a warning or error.

The main purpose of this functionality is for use in a "detect" failure message. They look like this:

```
======== Output: heroku/php@0.2.0 ========
No PHP project files found.
======== Results ========
fail: heroku/php@0.2.0
skip: heroku/procfile@3.1.2
======== Output: heroku/dotnet@0.1.4 ========
No .NET solution or project files (such as `foo.sln` or `foo.csproj`) found.
======== Results ========
fail: heroku/dotnet@0.1.4
skip: heroku/procfile@3.1.2
```

It's important that detect failure messages not have color to stand out because they're more like FYI messages than warnings or errors. I.e. that's why the buildpack could not run, but for a Ruby app, failing .NET detection is expected. I've updated this PR with some text in the living style guide suggesting using this for failure messages.

I added an example to the style guide that demonstrates this.