### PR TITLE
[stacked] Add buildpack and header print functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add: explicit `print::buildpack` and `print::header` functions that are focused on intent rather than implementation detail (https://github.com/heroku-buildpacks/bullet_stream/pull/34)
 - Add: `h3` header support (https://github.com/heroku-buildpacks/bullet_stream/pull/32)
 - Add: `global::print::plain` to print out plain text like `println!`. It auto-flushes IO, redirects to the global writer (if you wanted to capture everything), and enables "paragraph detection" if it's followed by something like a warning or error ()
 

--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -35,25 +35,19 @@ fn main() {
         "});
         print::plain("");
 
-        output = output.h2("Header usage");
-        let mut bullet = output.bullet(formatdoc! {"
-            Header levels
+        print::buildpack("Buildpack Name");
+        print::bullet("Use `print::buildpack()` to announce the name of your buildpack");
+        print::bullet(formatdoc! {"
+            Use the full name in a title case. For example: `heroku/ruby`
+            would become print::buildpack(\"Heroku Ruby Buildpack\");
         "});
-        bullet = bullet.sub_bullet(formatdoc! {"
-            H1: The H1 header appears at most once in a given output.
-        "});
-        bullet = bullet.sub_bullet(formatdoc! {"
-            H2: Buildpacks use H2 for announcing the name of the buildpack.
-
-            Use the full name in title case such as 'Heroku Ruby Buildpack'
-        "});
-        bullet = bullet.sub_bullet(formatdoc! {"
-            H3: The H3 header can be used to add an extra nesting level by breaking
+        print::header("Header");
+        print::bullet(formatdoc! {"
+            You can use `print::header()` to add an extra nesting level by breaking
             up bullet sections.
 
             Prefer using h2, bullet, and sub-bullet indentation levels when possible.
         "});
-        output = bullet.done();
 
         output = output.h2("Bullet section features");
         output = output

--- a/src/docs/global_setup.rs
+++ b/src/docs/global_setup.rs
@@ -1,5 +1,6 @@
 
 use bullet_stream::global::print;
+# use pretty_assertions::{assert_eq, assert_ne};
 #
 # let temp = tempfile::tempdir().unwrap();
 # let path = temp.path().join("log");

--- a/src/global.rs
+++ b/src/global.rs
@@ -171,7 +171,6 @@ pub mod print {
     ///
     /// ```
     #[doc = include_str!("./docs/global_setup.rs")]
-    ///
     /// print::plain("This almost seems silly.");
     /// print::plain("But it auto-flushes IO.");
     /// print::plain("Which is nice.");
@@ -183,6 +182,73 @@ pub mod print {
     /// ```
     pub fn plain(s: impl AsRef<str>) {
         write::plain(&mut GlobalWriter, s)
+    }
+
+    /// Announce the name of a buildpack
+    ///
+    /// Use together with [all_done]
+    /// ```
+    #[doc = include_str!("./docs/global_setup.rs")]
+    /// let started = print::buildpack("Heroku Awesome Buildpack");
+    /// print::bullet("Just add awesome.");
+    /// print::all_done(&Some(started));
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ### Heroku Awesome Buildpack
+    ///
+    /// - Just add awesome.
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
+    /// ```
+    pub fn buildpack(s: impl AsRef<str>) -> Instant {
+        write::h2(&mut GlobalWriter, s);
+        Instant::now()
+    }
+
+    /// Header to break up subsections in a buildpack's output
+    ///
+    /// ```
+    #[doc = include_str!("./docs/global_setup.rs")]
+    ///
+    /// let started = print::buildpack("FYEO Buildpack");
+    ///
+    /// print::header("the branches bending low");
+    /// print::bullet("Tracks");
+    /// print::sub_bullet("all the windows are glowing");
+    /// print::sub_bullet("looking in between those long reeds");
+    /// print::bullet("Released");
+    /// print::sub_bullet("2024");
+    ///
+    /// print::header("failed book plots");
+    /// print::bullet("Tracks");
+    /// print::sub_bullet("the stream at new river beach ");
+    /// print::sub_bullet("a line that is broad");
+    /// print::bullet("Released");
+    /// print::sub_bullet("2023");
+    ///
+    /// print::all_done(&Some(started));
+    #[doc = include_str!("./docs/global_done_one.rs")]
+    /// ### FYEO Buildpack
+    ///
+    /// #### the branches bending low
+    ///
+    /// - Tracks
+    ///   - all the windows are glowing
+    ///   - looking in between those long reeds
+    /// - Released
+    ///   - 2024
+    ///
+    /// #### failed book plots
+    ///
+    /// - Tracks
+    ///   - the stream at new river beach
+    ///   - a line that is broad
+    /// - Released
+    ///   - 2023
+    /// - Done (finished in < 0.1s)
+    #[doc = include_str!("./docs/global_done_two.rs")]
+    /// ```
+    pub fn header(s: impl AsRef<str>) {
+        write::h3(&mut GlobalWriter, s);
     }
 
     /// Output a bullet point to the global writer without state

--- a/src/write.rs
+++ b/src/write.rs
@@ -58,15 +58,7 @@ pub(crate) fn h3<W: TrailingParagraph>(writer: &mut W, s: impl AsRef<str>) {
         writeln!(writer).expect("writer open");
     }
 
-    writeln!(
-        writer,
-        "{}",
-        ansi_escape::wrap_ansi_escape_each_line(
-            &ANSI::BoldPurple,
-            format!("### {}", s.as_ref().trim()),
-        ),
-    )
-    .expect("writer open");
+    writeln!(writer, "### {}", s.as_ref().trim()).expect("writer open");
 
     if !writer.trailing_paragraph() {
         writeln!(writer).expect("writer open");


### PR DESCRIPTION
Adds explicit `print::buildpack` and `print::header` functions that are focused on intent rather than implementation detail.

This also removes styling from `h3` so only the buildpack name will be in bright purple (helps it stand out).