### PR TITLE
Fix style guide

### DIFF
--- a/examples/style_guide.rs
+++ b/examples/style_guide.rs
@@ -49,12 +49,10 @@ fn main() {
             Prefer using h2, bullet, and sub-bullet indentation levels when possible.
         "});
 
-        output = output.h2("Bullet section features");
-        output = output
-            .bullet("Bullet example")
-            .sub_bullet("sub bullet example one")
-            .sub_bullet("sub bullet example two")
-            .done();
+        print::h2("Bullet section features");
+        print::bullet("Bullet example");
+        print::sub_bullet("Sub bullet example one");
+        print::sub_bullet("Sub bullet example two");
 
         output = output
             .bullet("Bullet section description")


### PR DESCRIPTION
There should be a space before the header:

```
  Prefer using h2, bullet, and sub-bullet indentation levels when possible.
## Bullet section features
```

I debugged as far as identifying that the boundry between the type state and function outputs is part of the issue. I want to get rid of the type state implementation, so this is a good enough fix for now.