### PR TITLE
Remove need for `let _` with global timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Change: Result of `global::sub_start_timer(...).done()` is no longer "must use". This means it no longer needs `let _ =` for clippy. (https://github.com/heroku-buildpacks/bullet_stream/pull/38)
+
 ## v0.8.0 - 2024/04/24
 
 - Add: explicit `print::buildpack` and `print::header` functions that are focused on intent rather than implementation detail (https://github.com/heroku-buildpacks/bullet_stream/pull/34)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,6 @@ where
     ///
     /// Once you're finished with your long running task, calling this function
     /// finalizes the timer's output and transitions back to a [`state::SubBullet`].
-    #[must_use]
     pub fn done(self) -> Print<state::SubBullet<W>> {
         let duration = self.state.started.elapsed();
         let mut io = match self.state.write.stop() {

--- a/src/write.rs
+++ b/src/write.rs
@@ -116,7 +116,7 @@ where
         style::running_command(command.name()),
     );
     let output = command.named_output();
-    let _ = timer.done();
+    timer.done();
     output
 }
 


### PR DESCRIPTION
Before:

```
let timer = print::sub_start_timer("Installing");
// ...
let _ = timer.done();
```

After:

```
let timer = print::sub_start_timer("Installing");
// ...
timer.done();
```

This change removes the "must use" attribute from the return value of the stateful interface. The downside is that anyone using the stateful interface can call `.done()` here without doing anything else with the value. But that would also mean that nothing else in their code uses the value, so it's likely they didn't need it anyway.

I'm now advocating for the global "print" interface over the stateful interface.


Close #37