### PR TITLE
Re-export sub-dependencies of exposed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Change: Result of `global::sub_start_timer(...).done()` is no longer "must use". This means it no longer needs `let _ =` for clippy. (https://github.com/heroku-buildpacks/bullet_stream/pull/38)
+- Add: The `fun_run` library is re-exported when `feature = "fun_run"` is enabled (on by default). This is because our crate exposes types from `fun_run` in the form of an error result `fun_run::CmdError`, now someone can use that feature and that type via re-export and guarantee it's the same version. (https://github.com/heroku-buildpacks/bullet_stream/pull/39)
 
 ## v0.8.0 - 2024/04/24
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use style::CMD_INDENT;
 use util::TrailingParagraph;
 
 pub use ansi_escape::strip_ansi;
+#[cfg(feature = "fun_run")]
+pub use fun_run;
 
 mod ansi_escape;
 mod background_printer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,23 @@
 #![doc = include_str!("../README.md")]
-
 use crate::util::ParagraphInspectWrite;
 use crate::write::line_mapped;
+use global::GlobalWriter;
 use std::fmt::Debug;
 use std::io::Write;
 use std::time::Instant;
+use style::CMD_INDENT;
+use util::TrailingParagraph;
+
+pub use ansi_escape::strip_ansi;
 
 mod ansi_escape;
 mod background_printer;
 mod duration_format;
-pub mod global;
-pub mod style;
 mod util;
 mod write;
-pub use ansi_escape::strip_ansi;
-use global::GlobalWriter;
-use style::CMD_INDENT;
-use util::TrailingParagraph;
+
+pub mod global;
+pub mod style;
 
 /// Use [`Print`] to output structured text as a buildpack/script executes. The output
 /// is intended to be read by the application user.


### PR DESCRIPTION
The `fun_run` feature exposes the trait `CommandWithName` and the type `fun_run::CmdError`. If you try to use these with a different version of the `fun_run` crate you'll get an error. It can be difficult to debug as demonstrated in https://github.com/rust-lang/cargo/issues/15591.

This [blog suggested an easy fix](https://lobste.rs/s/iuvb8a/designing_error_types_rust_libraries): re-export any types your crate is using so your end users can depend on a unified version. It doesn't entirely scale if the end user has N crates with N different versions of `fun_run`, but it at least makes it better for the 1:1 case.
