### PR TITLE
Prepare release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.9.0 2025/06/05
+
 - Change: Result of `global::sub_start_timer(...).done()` is no longer "must use". This means it no longer needs `let _ =` for clippy. (https://github.com/heroku-buildpacks/bullet_stream/pull/38)
 - Add: The `fun_run` library is re-exported when `feature = "fun_run"` is enabled (on by default). This is because our crate exposes types from `fun_run` in the form of an error result `fun_run::CmdError`, now someone can use that feature and that type via re-export and guarantee it's the same version. (https://github.com/heroku-buildpacks/bullet_stream/pull/39)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "bullet_stream"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ascii_table",
  "fun_run",
@@ -192,9 +192,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fun_run"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60475c9540e62902b2b2e292be87f61df540c7e0f0bdb92416fd5ae792450049"
+checksum = "8edaa9292e7fb8dbab9a2a2b77e73ddb8b0d2504f74708ef0d265e0e9bf32b9b"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bullet_stream"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 description = "Bulletproof printing for bullet point text"


### PR DESCRIPTION
Some `must_use` declarations changed. According to cargo semver checks we should rev major. https://github.com/obi1kenobi/cargo-semver-checks/issues/1278#issuecomment-2945356722