### PR TITLE
Introduce `global::with_locked_writer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add: New function `global::with_locked_writer` is introduced to allow consistently capturing write output. This function is designed for use in testing output or in other non-reentrant capture cases. This blocks all threads using this function but one from executing so that a deterministic and consistent output is captured. Previously tests could be written with a thread_local writer, however there's a subtle race condition in that approach if the output relies on "paragraph" style text ().
+
 ## v0.9.0 2025/06/05
 
 - Change: Result of `global::sub_start_timer(...).done()` is no longer "must use". This means it no longer needs `let _ =` for clippy. (https://github.com/heroku-buildpacks/bullet_stream/pull/38)

--- a/src/global.rs
+++ b/src/global.rs
@@ -185,18 +185,24 @@ pub mod print {
     /// Output a h1 header to the global writer without state
     ///
     /// ```
-    #[doc = include_str!("./docs/global_setup.rs")]
+    /// use bullet_stream::global::print;
+    /// # use pretty_assertions::assert_eq;
+    /// #
+    /// # let output = bullet_stream::global::with_locked_writer(Vec::<u8>::new(), ||{
     ///
-    /// print::h1("I am a top level header");
     /// let duration = std::time::Instant::now();
-    /// // ...
+    /// print::h1("I am a top level header");
+    ///
     /// print::all_done(&Some(duration));
+    /// # });
     ///
-    #[doc = include_str!("./docs/global_done_one.rs")]
-    /// ## I am a top level header
+    /// let expected = indoc::formatdoc!{"
     ///
-    /// - Done (finished in < 0.1s)
-    #[doc = include_str!("./docs/global_done_two.rs")]
+    ///   ## I am a top level header
+    ///
+    ///   - Done (finished in < 0.1s)
+    /// "};
+    /// assert_eq!(expected, bullet_stream::strip_ansi(String::from_utf8_lossy(&output)));
     /// ```
     pub fn h1(s: impl AsRef<str>) {
         write::h1(&mut GlobalWriter, s);

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,7 +1,12 @@
 use crate::util::ParagraphInspectWrite;
 use crate::util::TrailingParagraph;
 use crate::util::TrailingParagraphSend;
+use std::any::Any;
+use std::cell::Cell;
 use std::io::Write;
+use std::panic::catch_unwind;
+use std::panic::resume_unwind;
+use std::panic::AssertUnwindSafe;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 
@@ -55,7 +60,7 @@ impl TrailingParagraph for GlobalWriter {
 ///
 /// # Panics
 ///
-/// If you try to pass in a `_GlobalWriter`
+/// - If you try to pass in a `GlobalWriter`
 pub fn set_writer<W>(new_writer: W)
 where
     W: Write + Send + 'static,
@@ -66,6 +71,87 @@ where
         let mut writer = WRITER.lock().unwrap();
         *writer = Box::new(ParagraphInspectWrite::new(new_writer));
     }
+}
+
+static WITH_WRITER_GLOBAL_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| ().into());
+thread_local! {
+    static WITH_WRITER_REENTRANT_CHECK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Sets the global writer for the duration of the provided closure
+///
+/// This is meant to be used in tests where the order of writes are important.
+///
+/// ```rust
+///
+/// let out = bullet_stream::global::with_locked_writer(Vec::<u8>::new(), || {
+///   bullet_stream::global::print::bullet("Hello world");
+/// });
+///
+/// assert_eq!("- Hello world\n".to_string(), String::from_utf8_lossy(&out));
+/// ```
+///
+/// Guarantees that only one invocation of this is called at a time. Returns the provided
+/// writer on completion. Panics if called recursively in the same thread.
+///
+/// # Panics
+///
+/// - If you mutate the global writer via another mechanism (such as calling `global::set_writer`)
+///   from within this thread.
+/// - If you try to call the function recursively in the same thread:
+///
+/// ```should_panic
+/// bullet_stream::global::with_locked_writer(Vec::<u8>::new(), || {
+///     bullet_stream::global::with_locked_writer(Vec::<u8>::new(), || {
+///         //
+///     });
+/// });
+/// ```
+///
+/// - If you try to pass in a `GlobalWriter`
+pub fn with_locked_writer<W, F>(new_writer: W, f: F) -> W
+where
+    W: Write + Send + Any + 'static,
+    F: FnOnce(),
+{
+    if std::any::Any::type_id(&new_writer) == std::any::TypeId::of::<GlobalWriter>() {
+        panic!("Cannot set the global writer to _GlobalWriter");
+    }
+    WITH_WRITER_REENTRANT_CHECK.with(|only_once| {
+        if only_once.get() {
+            panic!("Cannot call this function recursively!");
+        }
+        only_once.set(true);
+        // The function f() may panic, but
+        let w_or_panic = {
+            let _global_lock = WITH_WRITER_GLOBAL_LOCK.lock().unwrap();
+            let old_writer = {
+                let mut write_lock = WRITER.lock().unwrap();
+                std::mem::replace(
+                    &mut *write_lock,
+                    Box::new(ParagraphInspectWrite::new(new_writer)),
+                )
+            };
+            // Allow writes to happen on inner function call
+            let f_panic = catch_unwind(AssertUnwindSafe(f));
+
+            let new_writer = {
+                let mut write_lock = WRITER.lock().unwrap();
+                std::mem::replace(&mut *write_lock, old_writer)
+            };
+
+            if let Ok(original) =
+                (new_writer as Box<dyn Any>).downcast::<ParagraphInspectWrite<W>>()
+            {
+                f_panic.map(|_| original.inner)
+            } else {
+                panic!("Could not downcast to original type. Writer was mutated unexpectedly")
+            }
+        };
+        only_once.set(false);
+
+        w_or_panic.unwrap_or_else(|payload| resume_unwind(payload))
+    })
 }
 
 #[cfg(feature = "global_functions")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -76,8 +76,8 @@ pub(crate) trait TrailingParagraph: Write {
     fn trailing_newline_count(&self) -> usize;
 }
 
-pub(crate) trait TrailingParagraphSend: TrailingParagraph + Send {}
-impl<T> TrailingParagraphSend for T where T: TrailingParagraph + Send {}
+pub(crate) trait TrailingParagraphSend: TrailingParagraph + Any + Send {}
+impl<T> TrailingParagraphSend for T where T: TrailingParagraph + Any + Send {}
 
 impl<W> TrailingParagraph for ParagraphInspectWrite<W>
 where


### PR DESCRIPTION
New function `global::with_locked_writer` is introduced to allow consistently capturing write output. This function is designed for use in testing output or in other non-reentrant capture cases. This blocks all threads using this function but one from executing so that a deterministic and consistent output is captured. Previously tests could be written with a thread_local writer, however there's a subtle race condition in that approach if the output relies on "paragraph" style text.

The cause of that race condition is because `global::set_writer` not only mutates the writer, it also resets the trailing newlines count, which affects the output. This replacement for that behavior should be safer.