### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+#ECCN:Open Source
+#GUSINFO:Languages,Buildpacks Shared Tooling
+* @heroku-buildpacks/languages


### PR DESCRIPTION
So that this repo complies with the SFDC SCM requirements.

Based on eg:
https://github.com/heroku/libcnb.rs/blob/main/.github/CODEOWNERS