### PR TITLE
Align minimum rust version to 1.86

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+## v0.11.0 2025/07/01
+
+- Change/fix: Minimum supported Rust version is now officially 1.86. Previously released, v0.10.0, used a feature stabalized in 1.86 but did not correctly update the MSRV (https://github.com/heroku-buildpacks/bullet_stream/pull/47).
+
 ## v0.10.0 2025/06/09
 
+- Change: Uses a feature of Rust not supported until 1.86, although the MSRV was not correctly incremented in this release (https://github.com/heroku-buildpacks/bullet_stream/pull/43).
 - Add: New function `global::with_locked_writer` is introduced to allow consistently capturing write output. This function is designed for use in testing output or in other non-reentrant capture cases. This blocks all threads using this function but one from executing so that a deterministic and consistent output is captured. Previously tests could be written with a thread_local writer, however there's a subtle race condition in that approach if the output relies on "paragraph" style text (https://github.com/heroku-buildpacks/bullet_stream/pull/43).
 
 ## v0.9.0 2025/06/05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "bullet_stream"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ascii_table",
  "fun_run",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bullet_stream"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "Bulletproof printing for bullet point text"
@@ -9,6 +9,7 @@ repository = "https://github.com/schneems/bullet_stream"
 documentation = "https://docs.rs/bullet_stream"
 readme = "README.md"
 include = ["src/**/*", "LICENSE", "README.md"]
+rust-version = "1.86"
 
 [dependencies]
 fun_run = { version = ">=0.5,<1", optional = true }

--- a/src/global.rs
+++ b/src/global.rs
@@ -675,7 +675,7 @@ mod test {
             .join()
             .expect("First thread should complete successfully");
 
-        assert!(result.is_err(), "Expected panic to be caught {:?}", result);
+        assert!(result.is_err(), "Expected panic to be caught {result:?}");
 
         let handle2 = thread::spawn(|| {
             let output = with_locked_writer(Vec::new(), || {


### PR DESCRIPTION
An issue was mentioned in https://github.com/heroku/buildpacks-deb-packages/issues/110#issuecomment-2997899858. This code was added in https://github.com/heroku-buildpacks/bullet_stream/pull/43/files and uses a feature of Rust 1.86 https://www.reddit.com/r/rust/comments/1ip51qt/trait_upcasting_stabilized_in_186/ (https://github.com/rust-lang/rust/pull/134367). 

This usage wasn't realized at the time. No lints or tooling caught it. That Any upcast is critical for the feature introduced in #43. The easiest path forward is to align the MSRV with the reality of the current code.


Semver version bump guidance from this thread to make this a minor change: https://users.rust-lang.org/t/rust-version-requirement-change-as-semver-breaking-or-not/20980/2.

GUS-W-18939940